### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,8 @@
 name: CI/CD
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Unicorn-Dynamics/bolt.ml/security/code-scanning/1](https://github.com/Unicorn-Dynamics/bolt.ml/security/code-scanning/1)

To address the issue, the best approach is to explicitly add a `permissions` block at the root level of the workflow file to restrict the access granted to the GITHUB_TOKEN. This block will specify the minimum permissions required for the workflow.

In this case:
- The `contents: read` permission is sufficient for the workflow since it involves checking out the code and running tests without modifying repository contents.
- Adding the `permissions` block at the root level ensures all jobs in the workflow inherit these restricted permissions unless they define their own permissions block.

The change is localized to `.github/workflows/ci.yaml` to ensure no disruption to functionality while improving security.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
